### PR TITLE
Upgrade to .NET 9 and use new packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Install template

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Create package
       run: dotnet pack --configuration Release --no-build
     - name: Upload built package
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v4.3.5
       with:
         name: package
         path: bin/Release/mMosiur.AdventOfCode.DayTemplate.*.nupkg

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Create package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Create package
       run: dotnet pack --configuration Release --no-build
     - name: Upload built package
-      uses: actions/upload-artifact@v4.3.5
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: package
         path: bin/Release/mMosiur.AdventOfCode.DayTemplate.*.nupkg

--- a/AdventOfCode.DayTemplate.proj
+++ b/AdventOfCode.DayTemplate.proj
@@ -3,7 +3,7 @@
     <PackageId>mMosiur.AdventOfCode.DayTemplate</PackageId>
     <Authors>mMosiur</Authors>
     <Description>Template for creating an Advent of Code single day project.</Description>
-    <Version>1.4.3</Version>
+    <Version>1.4.4</Version>
     <RepositoryUrl>https://github.com/mMosiur/AdventOfCodeDayTemplate</RepositoryUrl>
     <PackageProjectUrl>https://github.com/mMosiur/AdventOfCodeDayTemplate</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/AdventOfCode.DayTemplate.proj
+++ b/AdventOfCode.DayTemplate.proj
@@ -3,7 +3,7 @@
     <PackageId>mMosiur.AdventOfCode.DayTemplate</PackageId>
     <Authors>mMosiur</Authors>
     <Description>Template for creating an Advent of Code single day project.</Description>
-    <Version>1.4.4</Version>
+    <Version>1.5.0</Version>
     <RepositoryUrl>https://github.com/mMosiur/AdventOfCodeDayTemplate</RepositoryUrl>
     <PackageProjectUrl>https://github.com/mMosiur/AdventOfCodeDayTemplate</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/content/DayXX.csproj
+++ b/content/DayXX.csproj
@@ -2,15 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>AdventOfCode.YearYYYY.DayXX</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mMosiur.AdventOfCode.Abstractions" Version="4.4.1" />
-    <PackageReference Include="mMosiur.AdventOfCode.Common" Version="0.1.5" />
+    <PackageReference Include="mMosiur.AdventOfCode.Common" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/DayXX.csproj
+++ b/content/DayXX.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="mMosiur.AdventOfCode.Abstractions" Version="4.4.1" />
-    <PackageReference Include="mMosiur.AdventOfCode.Common" Version="0.1.4" />
+    <PackageReference Include="mMosiur.AdventOfCode.Common" Version="0.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/DayXXSolver.cs
+++ b/content/DayXXSolver.cs
@@ -1,8 +1,8 @@
-using AdventOfCode.Abstractions;
+using AdventOfCode.Common;
 
 namespace AdventOfCode.YearYYYY.DayXX;
 
-public sealed class DayXXSolver : DaySolver
+public sealed class DayXXSolver : DaySolver<DayXXSolverOptions>
 {
 	public override int Year => YYYY;
 	public override int Day => XX;
@@ -11,12 +11,12 @@ public sealed class DayXXSolver : DaySolver
 	public DayXXSolver(DayXXSolverOptions options) : base(options)
 	{
 		// Initialize DayXX solver here.
+		// Property `Options` contains options passed to this constructor that were forwarded to the base constructor.
 		// Property `Input` contains the raw input text.
 		// Property `InputLines` enumerates lines in the input text.
 	}
 
-	public DayXXSolver(Action<DayXXSolverOptions> configure)
-		: this(DaySolverOptions.FromConfigureAction(configure))
+	public DayXXSolver(Action<DayXXSolverOptions> configure) : this(DaySolverOptions.FromConfigureAction(configure))
 	{
 	}
 

--- a/content/DayXXSolverOptions.cs
+++ b/content/DayXXSolverOptions.cs
@@ -1,4 +1,4 @@
-using AdventOfCode.Abstractions;
+using AdventOfCode.Common;
 
 namespace AdventOfCode.YearYYYY.DayXX;
 

--- a/content/Program.cs
+++ b/content/Program.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using AdventOfCode;
+using AdventOfCode.Common;
 using AdventOfCode.YearYYYY.DayXX;
 
 try


### PR DESCRIPTION
This pull request includes several updates to the project, focusing on upgrading dependencies, updating project configuration, and refactoring code to use a different library. The most important changes include upgrading the .NET version, updating package versions, and refactoring the code to use `AdventOfCode.Common` instead of `AdventOfCode.Abstractions`.

### Dependency and Configuration Updates:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L17-R17): Updated the .NET version from 8.0.x to 9.0.x.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L17-R23): Updated the .NET version from 8.0.x to 9.0.x and the `actions/upload-artifact` version from v4.3.4 to v4.4.3.
* [`AdventOfCode.DayTemplate.proj`](diffhunk://#diff-8376f5363b605fa9a7b5d031e47bf5f45a2cb184fedc5f2cdb598c024e8145b3L6-R6): Updated the project version from 1.4.3 to 1.5.0.
* [`content/DayXX.csproj`](diffhunk://#diff-4fcb4c64396862e4039c1f96e9644556f45eabbb34e4fc969b7d7390ae0796cbL5-R12): Updated the target framework from net8.0 to net9.0 and changed the package reference version for `mMosiur.AdventOfCode.Common` from 0.1.4 to 0.3.0.

### Code Refactoring:

* [`content/DayXXSolver.cs`](diffhunk://#diff-65f21d9505b8a1893cdbd28676ebb2e6b1b00e5f34de2cea4481e81b68951332L1-R5): Refactored to use `AdventOfCode.Common` instead of `AdventOfCode.Abstractions` and updated the class inheritance to `DaySolver<DayXXSolverOptions>`. [[1]](diffhunk://#diff-65f21d9505b8a1893cdbd28676ebb2e6b1b00e5f34de2cea4481e81b68951332L1-R5) [[2]](diffhunk://#diff-65f21d9505b8a1893cdbd28676ebb2e6b1b00e5f34de2cea4481e81b68951332R14-R19)
* [`content/DayXXSolverOptions.cs`](diffhunk://#diff-4b5759b33036256472136d2f7a1f4815560e7d247a2832f8cb9a76c624dc96f0L1-R1): Refactored to use `AdventOfCode.Common` instead of `AdventOfCode.Abstractions`.
* [`content/Program.cs`](diffhunk://#diff-6cc8700260aa8ae6cfbef0f39f4848f39f38195aa7e7c1b95ca6ec6ca4a2e45fL2-R2): Refactored to use `AdventOfCode.Common` instead of `AdventOfCode`.